### PR TITLE
default_value= 때문에 elearning 에서 extra_vars 가계속초기화됨

### DIFF
--- a/nproduct.admin.controller.php
+++ b/nproduct.admin.controller.php
@@ -364,7 +364,6 @@ class nproductAdminController extends nproduct
 	{
 		$oNproductModel = &getModel('nproduct');
 		// Default values
-		$args->default_value = '';
 		if(in_array($args->column_type, array('checkbox','select','radio')) && count($args->default_value) ) 
 		{
 			$args->default_value = serialize($args->default_value);


### PR DESCRIPTION
이것때문에 다른곳에서 
elearning 모듈 설치하고 mod inst 생성시 extra_vars 가 안들어감
